### PR TITLE
feat: support PSQL 15 unique nulls not distinct

### DIFF
--- a/src/decorator/Index.ts
+++ b/src/decorator/Index.ts
@@ -133,6 +133,8 @@ export function Index(
                     : true,
             where: options ? options.where : undefined,
             unique: options && options.unique ? true : false,
+            nullsNotDistinct:
+                options && options.nullsNotDistinct ? true : false,
             spatial: options && options.spatial ? true : false,
             fulltext: options && options.fulltext ? true : false,
             nullFiltered: options && options.nullFiltered ? true : false,

--- a/src/decorator/Unique.ts
+++ b/src/decorator/Unique.ts
@@ -100,6 +100,7 @@ export function Unique(
             name: name,
             columns,
             deferrable: options ? options.deferrable : undefined,
+            nullsNotDistinct: options ? options.nullsNotDistinct : undefined,
         }
         getMetadataArgsStorage().uniques.push(args)
     }

--- a/src/decorator/options/IndexOptions.ts
+++ b/src/decorator/options/IndexOptions.ts
@@ -8,6 +8,16 @@ export interface IndexOptions {
     unique?: boolean
 
     /**
+     * By default, NULL values are not treated as distinct entries.
+     * Specifying NULLS NOT DISTINCT on unique indexes
+     * will cause NULL values to be treated distinctly.
+     *
+     * Only applicable when unique: true.
+     * Works only in PostgreSQL 15 and above.
+     */
+    nullsNotDistinct?: boolean
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL and PostgreSQL.
      */

--- a/src/decorator/options/UniqueOptions.ts
+++ b/src/decorator/options/UniqueOptions.ts
@@ -8,4 +8,13 @@ export interface UniqueOptions {
      * Indicate if unique constraints can be deferred.
      */
     deferrable?: DeferrableType
+
+    /**
+     * By default, NULL values are not treated as distinct entries.
+     * Specifying NULLS NOT DISTINCT on unique constraints
+     * will cause NULL values to be treated distinctly.
+     *
+     * Works only in PostgreSQL 15 and above.
+     */
+    nullsNotDistinct?: boolean
 }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1093,7 +1093,9 @@ export class PostgresQueryRunner
                 new Query(
                     `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${
                         uniqueConstraint.name
-                    }" UNIQUE ("${column.name}")`,
+                    }" UNIQUE ${
+                        column.isNullsNotDistinct ? "NULLS NOT DISTINCT" : ""
+                    } ("${column.name}")`,
                 ),
             )
             downQueries.push(
@@ -1845,7 +1847,10 @@ export class PostgresQueryRunner
                 }
             }
 
-            if (newColumn.isUnique !== oldColumn.isUnique) {
+            if (
+                newColumn.isUnique !== oldColumn.isUnique ||
+                newColumn.isNullsNotDistinct !== oldColumn.isNullsNotDistinct
+            ) {
                 if (newColumn.isUnique === true) {
                     const uniqueConstraint = new TableUnique({
                         name: this.connection.namingStrategy.uniqueConstraintName(
@@ -1861,7 +1866,11 @@ export class PostgresQueryRunner
                                 table,
                             )} ADD CONSTRAINT "${
                                 uniqueConstraint.name
-                            }" UNIQUE ("${newColumn.name}")`,
+                            }" UNIQUE ${
+                                newColumn.isNullsNotDistinct
+                                    ? "NULLS NOT DISTINCT"
+                                    : ""
+                            } ("${newColumn.name}")`,
                         ),
                     )
                     downQueries.push(
@@ -3201,7 +3210,9 @@ export class PostgresQueryRunner
 
         const indicesSql =
             `SELECT "ns"."nspname" AS "table_schema", "t"."relname" AS "table_name", "i"."relname" AS "constraint_name", "a"."attname" AS "column_name", ` +
-            `CASE "ix"."indisunique" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_unique", pg_get_expr("ix"."indpred", "ix"."indrelid") AS "condition", ` +
+            `CASE "ix"."indisunique" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_unique", ` +
+            `CASE "ix"."indnullsnotdistinct" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_nulls_not_distinct", ` +
+            `pg_get_expr("ix"."indpred", "ix"."indrelid") AS "condition", ` +
             `"types"."typname" AS "type_name" ` +
             `FROM "pg_class" "t" ` +
             `INNER JOIN "pg_index" "ix" ON "ix"."indrelid" = "t"."oid" ` +
@@ -3261,6 +3272,8 @@ export class PostgresQueryRunner
                     name: constraint["constraint_name"],
                     columnNames: indices.map((i) => i["column_name"]),
                     isUnique: constraint["is_unique"] === "TRUE",
+                    isNullsNotDistinct:
+                        constraint["is_nulls_not_distinct"] === "TRUE",
                     where: constraint["condition"],
                     isFulltext: false,
                 })
@@ -3353,8 +3366,10 @@ export class PostgresQueryRunner
 
         const indicesSql =
             `SELECT "ns"."nspname" AS "table_schema", "t"."relname" AS "table_name", "i"."relname" AS "constraint_name", "a"."attname" AS "column_name", ` +
-            `CASE "ix"."indisunique" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_unique", pg_get_expr("ix"."indpred", "ix"."indrelid") AS "condition", ` +
-            `"types"."typname" AS "type_name", "am"."amname" AS "index_type" ` +
+            `CASE "ix"."indisunique" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_unique", ` +
+            `CASE "ix"."indnullsnotdistinct" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_nulls_not_distinct", ` +
+            `pg_get_expr("ix"."indpred", "ix"."indrelid") AS "condition", ` +
+            `"types"."typname" AS "type_name" ` +
             `FROM "pg_class" "t" ` +
             `INNER JOIN "pg_index" "ix" ON "ix"."indrelid" = "t"."oid" ` +
             `INNER JOIN "pg_attribute" "a" ON "a"."attrelid" = "t"."oid"  AND "a"."attnum" = ANY ("ix"."indkey") ` +
@@ -3850,6 +3865,10 @@ export class PostgresQueryRunner
                         deferrable: constraint["deferrable"]
                             ? constraint["deferred"]
                             : undefined,
+                        nullsNotDistinct:
+                            constraint["expression"].includes(
+                                "NULLS NOT DISTINCT",
+                            ),
                     })
                 })
 
@@ -3983,6 +4002,8 @@ export class PostgresQueryRunner
                         name: constraint["constraint_name"],
                         columnNames: indices.map((i) => i["column_name"]),
                         isUnique: constraint["is_unique"] === "TRUE",
+                        isNullsNotDistinct:
+                            constraint["is_nulls_not_distinct"] === "TRUE",
                         where: constraint["condition"],
                         isSpatial: constraint["index_type"] === "gist",
                         isFulltext: false,
@@ -4019,6 +4040,7 @@ export class PostgresQueryRunner
                                 [column.name],
                             ),
                             columnNames: [column.name],
+                            nullsNotDistinct: column.isNullsNotDistinct,
                         }),
                     )
             })
@@ -4035,7 +4057,9 @@ export class PostgresQueryRunner
                     const columnNames = unique.columnNames
                         .map((columnName) => `"${columnName}"`)
                         .join(", ")
-                    let constraint = `CONSTRAINT "${uniqueName}" UNIQUE (${columnNames})`
+                    let constraint = `CONSTRAINT "${uniqueName}" UNIQUE ${
+                        unique.nullsNotDistinct ? "NULLS NOT DISTINCT" : ""
+                    } (${columnNames})`
                     if (unique.deferrable)
                         constraint += ` DEFERRABLE ${unique.deferrable}`
                     return constraint
@@ -4301,7 +4325,9 @@ export class PostgresQueryRunner
                 index.isConcurrent ? " CONCURRENTLY" : ""
             } "${index.name}" ON ${this.escapePath(table)} ${
                 index.isSpatial ? "USING GiST " : ""
-            }(${columns}) ${index.where ? "WHERE " + index.where : ""}`,
+            }(${columns}) ${
+                index.isNullsNotDistinct ? "NULLS NOT DISTINCT" : ""
+            } ${index.where ? "WHERE " + index.where : ""}`,
         )
     }
 
@@ -4316,8 +4342,8 @@ export class PostgresQueryRunner
             `CREATE ${index.isUnique ? "UNIQUE " : ""}INDEX "${
                 index.name
             }" ON ${this.escapePath(view)} (${columns}) ${
-                index.where ? "WHERE " + index.where : ""
-            }`,
+                index.isNullsNotDistinct ? "NULLS NOT DISTINCT" : ""
+            } ${index.where ? "WHERE " + index.where : ""}`,
         )
     }
 
@@ -4403,7 +4429,9 @@ export class PostgresQueryRunner
             .join(", ")
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${
             uniqueConstraint.name
-        }" UNIQUE (${columnNames})`
+        }" UNIQUE ${
+            uniqueConstraint.nullsNotDistinct ? "NULLS NOT DISTINCT" : ""
+        } (${columnNames})`
         if (uniqueConstraint.deferrable)
             sql += ` DEFERRABLE ${uniqueConstraint.deferrable}`
         return new Query(sql)

--- a/src/entity-schema/EntitySchemaIndexOptions.ts
+++ b/src/entity-schema/EntitySchemaIndexOptions.ts
@@ -27,6 +27,11 @@ export interface EntitySchemaIndexOptions {
     unique?: boolean
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL and PostgreSQL.
      */

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -283,6 +283,8 @@ export class EntitySchemaTransformer {
                     target: options.target || options.name,
                     name: index.name,
                     unique: index.unique === true ? true : false,
+                    nullsNotDistinct:
+                        index.nullsNotDistinct === true ? true : false,
                     spatial: index.spatial === true ? true : false,
                     fulltext: index.fulltext === true ? true : false,
                     nullFiltered: index.nullFiltered === true ? true : false,

--- a/src/metadata-args/IndexMetadataArgs.ts
+++ b/src/metadata-args/IndexMetadataArgs.ts
@@ -23,6 +23,11 @@ export interface IndexMetadataArgs {
     unique?: boolean
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL.
      */

--- a/src/metadata-args/UniqueMetadataArgs.ts
+++ b/src/metadata-args/UniqueMetadataArgs.ts
@@ -23,4 +23,9 @@ export interface UniqueMetadataArgs {
      * Indicate if unique constraints can be deferred.
      */
     deferrable?: DeferrableType
+
+    /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
 }

--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -29,6 +29,11 @@ export class IndexMetadata {
     isUnique: boolean = false
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    isNullsNotDistinct: boolean = false
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL.
      */
@@ -147,6 +152,7 @@ export class IndexMetadata {
             )
                 this.synchronize = options.args.synchronize
             this.isUnique = !!options.args.unique
+            this.isNullsNotDistinct = !!options.args.nullsNotDistinct
             this.isSpatial = !!options.args.spatial
             this.isFulltext = !!options.args.fulltext
             this.isNullFiltered = !!options.args.nullFiltered

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -40,6 +40,11 @@ export class UniqueMetadata {
     deferrable?: DeferrableType
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
+
+    /**
      * User specified unique constraint name.
      */
     givenName?: string
@@ -83,6 +88,7 @@ export class UniqueMetadata {
             this.givenName = options.args.name
             this.givenColumnNames = options.args.columns
             this.deferrable = options.args.deferrable
+            this.nullsNotDistinct = options.args.nullsNotDistinct
         }
     }
 

--- a/src/schema-builder/options/TableColumnOptions.ts
+++ b/src/schema-builder/options/TableColumnOptions.ts
@@ -52,6 +52,11 @@ export interface TableColumnOptions {
     isUnique?: boolean
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    isNullsNotDistinct?: boolean
+
+    /**
      * Indicates if column stores array.
      */
     isArray?: boolean

--- a/src/schema-builder/options/TableIndexOptions.ts
+++ b/src/schema-builder/options/TableIndexOptions.ts
@@ -22,6 +22,11 @@ export interface TableIndexOptions {
     isUnique?: boolean
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    isNullsNotDistinct?: boolean
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL.
      */

--- a/src/schema-builder/options/TableUniqueOptions.ts
+++ b/src/schema-builder/options/TableUniqueOptions.ts
@@ -21,4 +21,9 @@ export interface TableUniqueOptions {
      * or at the end of a transaction
      */
     deferrable?: string
+
+    /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
 }

--- a/src/schema-builder/table/TableColumn.ts
+++ b/src/schema-builder/table/TableColumn.ts
@@ -57,6 +57,11 @@ export class TableColumn {
     isUnique: boolean = false
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    isNullsNotDistinct: boolean = false
+
+    /**
      * Indicates if column stores array.
      */
     isArray: boolean = false
@@ -175,6 +180,7 @@ export class TableColumn {
             this.generatedIdentity = options.generatedIdentity
             this.isPrimary = options.isPrimary || false
             this.isUnique = options.isUnique || false
+            this.isNullsNotDistinct = options.isNullsNotDistinct || false
             this.isArray = options.isArray || false
             this.comment = options.comment
             this.enum = options.enum

--- a/src/schema-builder/table/TableIndex.ts
+++ b/src/schema-builder/table/TableIndex.ts
@@ -27,6 +27,11 @@ export class TableIndex {
     isUnique: boolean
 
     /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    isNullsNotDistinct: boolean
+
+    /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
      * Works only in MySQL.
      */
@@ -72,6 +77,7 @@ export class TableIndex {
         this.name = options.name
         this.columnNames = options.columnNames
         this.isUnique = !!options.isUnique
+        this.isNullsNotDistinct = !!options.isNullsNotDistinct
         this.isSpatial = !!options.isSpatial
         this.isConcurrent = !!options.isConcurrent
         this.isFulltext = !!options.isFulltext
@@ -92,6 +98,7 @@ export class TableIndex {
             name: this.name,
             columnNames: [...this.columnNames],
             isUnique: this.isUnique,
+            isNullsNotDistinct: this.isNullsNotDistinct,
             isSpatial: this.isSpatial,
             isConcurrent: this.isConcurrent,
             isFulltext: this.isFulltext,
@@ -115,6 +122,7 @@ export class TableIndex {
                 (column) => column.databaseName,
             ),
             isUnique: indexMetadata.isUnique,
+            isNullsNotDistinct: indexMetadata.isNullsNotDistinct,
             isSpatial: indexMetadata.isSpatial,
             isConcurrent: indexMetadata.isConcurrent,
             isFulltext: indexMetadata.isFulltext,

--- a/src/schema-builder/table/TableUnique.ts
+++ b/src/schema-builder/table/TableUnique.ts
@@ -27,6 +27,11 @@ export class TableUnique {
      */
     deferrable?: string
 
+    /**
+     * Indicates if column handle nulls values as distinct.
+     */
+    nullsNotDistinct?: boolean
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -35,6 +40,7 @@ export class TableUnique {
         this.name = options.name
         this.columnNames = options.columnNames
         this.deferrable = options.deferrable
+        this.nullsNotDistinct = options.nullsNotDistinct
     }
 
     // -------------------------------------------------------------------------
@@ -66,6 +72,7 @@ export class TableUnique {
                 (column) => column.databaseName,
             ),
             deferrable: uniqueMetadata.deferrable,
+            nullsNotDistinct: uniqueMetadata.nullsNotDistinct,
         })
     }
 }

--- a/test/github-issues/9827/entity/ConstraintEntity.ts
+++ b/test/github-issues/9827/entity/ConstraintEntity.ts
@@ -1,0 +1,14 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Unique } from "../../../../src"
+
+@Entity()
+@Unique("unique_constraint", ["value"], { nullsNotDistinct: true })
+export class ConstraintEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "varchar", nullable: true })
+    value: string
+}

--- a/test/github-issues/9827/entity/IndexEntity.ts
+++ b/test/github-issues/9827/entity/IndexEntity.ts
@@ -1,0 +1,20 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Index } from "../../../../src"
+
+@Entity()
+@Index("unique_index", ["value", "other_value"], {
+    unique: true,
+    nullsNotDistinct: true,
+})
+export class IndexEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "varchar", nullable: true })
+    value: string
+
+    @Column({ type: "varchar", nullable: true })
+    other_value: string
+}

--- a/test/github-issues/9827/issue-9827.ts
+++ b/test/github-issues/9827/issue-9827.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/index"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { ConstraintEntity } from "./entity/ConstraintEntity"
+import { IndexEntity } from "./entity/IndexEntity"
+
+describe("github issues > #9827 Support PostgreSQL 15 UNIQUE NULLS NOT DISTINCT", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [ConstraintEntity, IndexEntity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    after(() => closeTestingConnections(connections))
+    it("should create a unique constraint with nulls not distinct", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+                let table = await queryRunner.getTable("constraint_entity")
+                table?.uniques[0].nullsNotDistinct?.should.be.equal(true)
+            }),
+        ))
+
+    it("should create a unique index with nulls not distinct", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+                let table = await queryRunner.getTable("index_entity")
+                table?.indices[0].isNullsNotDistinct?.should.be.equal(true)
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #9827

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This MR fix adds the nullsNotDistinct option for unique constraints and indexes.
This option is available with Postgresql 15 to handle all null values as the same value.

Example : 
A Table(id, value), without a unique null not distinct on the value column
You'll be able to create (1, NULL) and (2, NULL) even if it should be unique

A Table(id, value), with a unique null not distinct on the value column
If you create (1, NULL) and then (2, NULL), you'll get a duplicate key error

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9827`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
